### PR TITLE
Some changes to Makefile and src/JHPWMPCA9685.h

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,2 +1,2 @@
 all:
-	g++ servoExample.cpp ../src/JHPWMPCA9685.cpp -I../src -o servoExample
+	g++ servoExample.cpp ../src/JHPWMPCA9685.cpp -li2c -I../src -o servoExample

--- a/src/JHPWMPCA9685.h
+++ b/src/JHPWMPCA9685.h
@@ -26,13 +26,18 @@ SOFTWARE.
 #define _JHPWMPCA9685_H
 
 #include <cstddef>
-#include <linux/i2c-dev.h>
 #include <sys/ioctl.h>
 #include <cstdlib>
 #include <cstdio>
 #include <fcntl.h>
 #include <unistd.h>
 #include <errno.h>
+
+extern "C" 
+{
+	#include <linux/i2c-dev.h>
+	#include <i2c/smbus.h>
+}
 
 class PCA9685
 {


### PR DESCRIPTION
Hi JetsonHacks, 

Thanks for your many helpful videos. :) 

I was not able to compile JHPWMPCA9685.cpp because of 'i2c_smbus_read_byte_data()' and 'i2c_smbus_write_data()' are not declared in linux/i2c-dev.h. I figured it's declared in i2c/smbus.h and it also needs link configuration in Makefile. 

Hope this helps. 